### PR TITLE
feat: Implement datagram send/receive support

### DIFF
--- a/client.go
+++ b/client.go
@@ -105,7 +105,7 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	}
 	str := rsp.Body.(http3.HTTPStreamer).HTTPStream()
 	conn := d.conns.AddSession(
-		rsp.Body.(http3.Hijacker).StreamCreator(),
+		rsp.Body.(http3.Hijacker).StreamCreator().(quic.Connection),
 		sessionID(str.StreamID()),
 		str,
 	)

--- a/server.go
+++ b/server.go
@@ -171,7 +171,7 @@ func (s *Server) Upgrade(w http.ResponseWriter, r *http.Request) (*Conn, error) 
 		return nil, errors.New("failed to hijack")
 	}
 	return s.conns.AddSession(
-		hijacker.StreamCreator(),
+		hijacker.StreamCreator().(quic.Connection),
 		sID,
 		r.Body.(http3.HTTPStreamer).HTTPStream(),
 	), nil

--- a/session_manager.go
+++ b/session_manager.go
@@ -155,7 +155,7 @@ func (m *sessionManager) handleUniStream(str quic.ReceiveStream, session *sessio
 }
 
 // AddSession adds a new WebTransport session.
-func (m *sessionManager) AddSession(qconn http3.StreamCreator, id sessionID, requestStr io.ReadWriteCloser) *Conn {
+func (m *sessionManager) AddSession(qconn quic.Connection, id sessionID, requestStr io.ReadWriteCloser) *Conn {
 	conn := newConn(id, qconn, requestStr)
 
 	m.mx.Lock()


### PR DESCRIPTION
Only thing it required that I'm "eh" about is the cast to `quic.Connection`.
Maybe we are missing some interface surface in quic-go that should be added?
