### PR TITLE
expose quic-go's connection tracing ID on the Session.Context

### DIFF
--- a/session.go
+++ b/session.go
@@ -74,7 +74,8 @@ type Session struct {
 }
 
 func newSession(sessionID sessionID, qconn http3.StreamCreator, requestStr quic.Stream) *Session {
-	ctx, ctxCancel := context.WithCancel(context.Background())
+	tracingID := qconn.Context().Value(quic.ConnectionTracingKey).(uint64)
+	ctx, ctxCancel := context.WithCancel(context.WithValue(context.Background(), quic.ConnectionTracingKey, tracingID))
 	c := &Session{
 		sessionID:       sessionID,
 		qconn:           qconn,

--- a/session_test.go
+++ b/session_test.go
@@ -1,6 +1,7 @@
 package webtransport
 
 import (
+	"context"
 	"io"
 	"testing"
 
@@ -40,6 +41,7 @@ func TestCloseStreamsOnClose(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockSess := NewMockStreamCreator(ctrl)
+	mockSess.EXPECT().Context().Return(context.WithValue(context.Background(), quic.ConnectionTracingKey, uint64(1337)))
 	sess := newSession(42, mockSess, newMockRequestStream(ctrl))
 
 	str := NewMockStream(ctrl)
@@ -63,7 +65,10 @@ func TestAddStreamAfterSessionClose(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	sess := newSession(42, NewMockStreamCreator(ctrl), newMockRequestStream(ctrl))
+	mockSess := NewMockStreamCreator(ctrl)
+	mockSess.EXPECT().Context().Return(context.WithValue(context.Background(), quic.ConnectionTracingKey, uint64(1337)))
+
+	sess := newSession(42, mockSess, newMockRequestStream(ctrl))
 	require.NoError(t, sess.Close())
 
 	str := NewMockStream(ctrl)


### PR DESCRIPTION
Depends on https://github.com/lucas-clemente/quic-go/pull/3601.